### PR TITLE
Add varnames to mapping in data loading function

### DIFF
--- a/climate_index_collection/data_loading.py
+++ b/climate_index_collection/data_loading.py
@@ -54,11 +54,17 @@ VARNAME_MAPPING = {
         "slp": "sea-level-pressure",
         "tsw": "sea-surface-temperature",
         "geopoth": "geopotential-height",
+        "temp2": "sea-air-temperature",
+        "sosaline": "sea-surface-salinity",
+        "precip": "precipitation",
     },
     "CESM": {
         "PSL": "sea-level-pressure",
         "SST": "sea-surface-temperature",
         "Z3": "geopotential-height",
+        "TS": "sea-air-temperature",
+        "SALT": "sea-surface-salinity",
+        "PRECT": "precipitation",
     },
 }
 


### PR DESCRIPTION
Since we added test data for sea air temperature, sea surface salinity and precipitation, this is necessary to have similar default names for attributes in both models' data.