### PR TITLE
Removed sea-air-temperature from OCEAN_ONLY_VARS (#94)

### DIFF
--- a/climate_index_collection/data_loading.py
+++ b/climate_index_collection/data_loading.py
@@ -127,7 +127,6 @@ VARNAME_MAPPING = {
 
 OCEAN_ONLY_VARS = (
     "sea-surface-temperature",
-    "sea-air-temperature",
     "sea-surface-salinity",
 )
 


### PR DESCRIPTION
Removed sea-air-temperature from OCEAN_ONLY_VARS
Closes #94 and #95 .