### PR TITLE
Add further indices

### DIFF
--- a/climate_index_collection/indices.py
+++ b/climate_index_collection/indices.py
@@ -276,7 +276,7 @@ def el_nino_southern_oscillation_12(data_set, sst_name="sea-surface-temperature"
 
     Following https://climatedataguide.ucar.edu/climate-data/nino-sst-indices-nino-12-3-34-4-oni-and-tni
     the index is derived from equatorial pacific sea-surface temperature (SST) anomalies in a box
-    borderd by 0°S - 10°S and 90°W - 80°W. This translates to -10°N - 0°N and 270°E - 280°E.
+    bordered by 0°S - 10°S and 90°W - 80°W. This translates to -10°N - 0°N and 270°E - 280°E.
     The Niño 1+2 region is the smallest and eastern-most of the Niño regions,
     and corresponds with the region of coastal South America where El Niño was first recognized by the local populations.
     This index tends to have the largest variance of the Niño SST indices.
@@ -328,7 +328,7 @@ def el_nino_southern_oscillation_3(data_set, sst_name="sea-surface-temperature")
 
     Following https://climatedataguide.ucar.edu/climate-data/nino-sst-indices-nino-12-3-34-4-oni-and-tni
     the index is derived from equatorial pacific sea-surface temperature (SST) anomalies in a box
-    borderd by 5°S - 5°N and 150°W - 90°W. This translates to -5°N - 5°N and 210°E - 270°E.
+    bordered by 5°S - 5°N and 150°W - 90°W. This translates to -5°N - 5°N and 210°E - 270°E.
     This region was once the primary focus for monitoring and predicting El Niño, but researchers later
     learned that the key region for coupled ocean-atmosphere interactions for ENSO lies further west.
     Hence, the Niño 3.4 became favored for defining El Niño and La Niña events.
@@ -380,7 +380,7 @@ def el_nino_southern_oscillation_34(data_set, sst_name="sea-surface-temperature"
 
     Following https://climatedataguide.ucar.edu/climate-data/nino-sst-indices-nino-12-3-34-4-oni-and-tni
     the index is derived from equatorial pacific sea-surface temperature (SST) anomalies in a box
-    borderd by 5°S - 5°N and 170°W - 120°W. This translates to -5°N - 5°N and 190°E - 240°E.
+    bordered by 5°S - 5°N and 170°W - 120°W. This translates to -5°N - 5°N and 190°E - 240°E.
 
     Computation is done as follows:
     1. Compute area averaged total SST from Niño 3.4 region.
@@ -429,7 +429,7 @@ def el_nino_southern_oscillation_4(data_set, sst_name="sea-surface-temperature")
 
     Following https://climatedataguide.ucar.edu/climate-data/nino-sst-indices-nino-12-3-34-4-oni-and-tni
     the index is derived from equatorial pacific sea-surface temperature (SST) anomalies in a box
-    borderd by 5°S - 5°N, 160°E - 150°W. This translates to -5°N - 5°N and 160°E - 210°E.
+    bordered by 5°S - 5°N and 160°E - 150°W. This translates to -5°N - 5°N and 160°E - 210°E.
 
     Computation is done as follows:
     1. Compute area averaged total SST from Niño 4 region.
@@ -473,8 +473,265 @@ def el_nino_southern_oscillation_4(data_set, sst_name="sea-surface-temperature")
     return ENSO4_index
 
 
+def tropical_north_atlantic_SST(data_set, sst_name="sea-surface-temperature"):
+    """Calculate the sea-surface temperature (SST) anomaly index in the Tropical North Atlantic (SSTA_TNA)
+
+    The Tropical North Atlantic region is defined by a box bordered by 5°N to 25°N and 55°W to 15°W.
+    This translates to 5°N to 25°N and 305°E to 345°E.
+
+    Computation is done as follows:
+    1. Compute area averaged total SST in the region of interest.
+    2. Compute monthly climatology for area averaged total SST from that region.
+    3. Subtract climatology from area averaged total SST time series to obtain anomalies.
+    4. Normalize anomalies by its standard deviation over the climatological period.
+
+    Parameters
+    ----------
+    data_set: xarray.DataSet
+        Dataset containing an SST field.
+    sst_name: str
+        Name of the Sea-Surface Temperature field. Defaults to "sea-surface-temperature".
+
+    Returns
+    -------
+    xarray.DataArray
+        Time series containing the SSTA_TNA index.
+
+    """
+    sst = area_mean_weighted(
+        dobj=data_set[sst_name],
+        lat_south=5,
+        lat_north=25,
+        lon_west=305,
+        lon_east=345,
+    )
+
+    climatology = sst.groupby("time.month").mean("time")
+
+    std_dev = sst.std("time")
+
+    SSTA_TNA = (sst.groupby("time.month") - climatology) / std_dev
+    SSTA_TNA = SSTA_TNA.rename("SSTA_TNA")
+
+    return SSTA_TNA
+
+
+def tropical_south_atlantic_SST(data_set, sst_name="sea-surface-temperature"):
+    """Calculate the sea-surface temperature (SST) anomaly index in the Tropical South Atlantic (SSTA_TSA)
+
+    The Tropical South Atlantic region is defined by a box bordered by 20°S to 0°N and 30°W to 10°E.
+    This translates to -20°N to 0°N and 330°E to 10°E.
+
+    Computation is done as follows:
+    1. Compute area averaged total SST in the region of interest.
+    2. Compute monthly climatology for area averaged total SST from that region.
+    3. Subtract climatology from area averaged total SST time series to obtain anomalies.
+    4. Normalize anomalies by its standard deviation over the climatological period.
+
+    Parameters
+    ----------
+    data_set: xarray.DataSet
+        Dataset containing an SST field.
+    sst_name: str
+        Name of the Sea-Surface Temperature field. Defaults to "sea-surface-temperature".
+
+    Returns
+    -------
+    xarray.DataArray
+        Time series containing the SSTA_TSA index.
+
+    """
+    sst = area_mean_weighted(
+        dobj=data_set[sst_name],
+        lat_south=-20,
+        lat_north=0,
+        lon_west=330,
+        lon_east=10,
+    )
+
+    climatology = sst.groupby("time.month").mean("time")
+
+    std_dev = sst.std("time")
+
+    SSTA_TSA = (sst.groupby("time.month") - climatology) / std_dev
+    SSTA_TSA = SSTA_TSA.rename("SSTA_TSA")
+
+    return SSTA_TSA
+
+
+def eastern_subtropical_indian_ocean_SST(data_set, sst_name="sea-surface-temperature"):
+    """Calculate the sea-surface temperature (SST) anomaly index in the Eastern Subtropical Indian Ocean (SSTA_ESIO)
+
+    The Eastern Subtropical Indian Ocean region is defined by a box bordered by 28°S to 18°S and 90°E to 100°E.
+    This translates to -28°N to -18°N and 90°E to 100°E.
+
+    Computation is done as follows:
+    1. Compute area averaged total SST in the region of interest.
+    2. Compute monthly climatology for area averaged total SST from that region.
+    3. Subtract climatology from area averaged total SST time series to obtain anomalies.
+    4. Normalize anomalies by its standard deviation over the climatological period.
+
+    Parameters
+    ----------
+    data_set: xarray.DataSet
+        Dataset containing an SST field.
+    sst_name: str
+        Name of the Sea-Surface Temperature field. Defaults to "sea-surface-temperature".
+
+    Returns
+    -------
+    xarray.DataArray
+        Time series containing the SSTA_ESIO index.
+
+    """
+    sst = area_mean_weighted(
+        dobj=data_set[sst_name],
+        lat_south=-28,
+        lat_north=-18,
+        lon_west=90,
+        lon_east=100,
+    )
+
+    climatology = sst.groupby("time.month").mean("time")
+
+    std_dev = sst.std("time")
+
+    SSTA_ESIO = (sst.groupby("time.month") - climatology) / std_dev
+    SSTA_ESIO = SSTA_ESIO.rename("SSTA_ESIO")
+
+    return SSTA_ESIO
+
+
+def western_subtropical_indian_ocean_SST(data_set, sst_name="sea-surface-temperature"):
+    """Calculate the sea-surface temperature (SST) anomaly index in the Western Subtropical Indian Ocean (SSTA_WSIO)
+
+    The Western Subtropical Indian Ocean region is defined by a box bordered by 37°S to 27°S and 55°E to 65°E.
+    This translates to -37°N to -27°N and 55°E to 65°E.
+
+    Computation is done as follows:
+    1. Compute area averaged total SST in the region of interest.
+    2. Compute monthly climatology for area averaged total SST from that region.
+    3. Subtract climatology from area averaged total SST time series to obtain anomalies.
+    4. Normalize anomalies by its standard deviation over the climatological period.
+
+    Parameters
+    ----------
+    data_set: xarray.DataSet
+        Dataset containing an SST field.
+    sst_name: str
+        Name of the Sea-Surface Temperature field. Defaults to "sea-surface-temperature".
+
+    Returns
+    -------
+    xarray.DataArray
+        Time series containing the SSTA_WSIO index.
+
+    """
+    sst = area_mean_weighted(
+        dobj=data_set[sst_name],
+        lat_south=-37,
+        lat_north=-27,
+        lon_west=55,
+        lon_east=65,
+    )
+
+    climatology = sst.groupby("time.month").mean("time")
+
+    std_dev = sst.std("time")
+
+    SSTA_WSIO = (sst.groupby("time.month") - climatology) / std_dev
+    SSTA_WSIO = SSTA_WSIO.rename("SSTA_WSIO")
+
+    return SSTA_WSIO
+
+
+def mediterranean_SST(data_set, sst_name="sea-surface-temperature"):
+    """Calculate the sea-surface temperature (SST) anomaly index in the Mediterranean Sea (SSTA_MED)
+
+    The Mediterranean Sea region is defined by a box bordered by 30°N to 45°N and 0°E to 25°E.
+
+    Computation is done as follows:
+    1. Compute area averaged total SST in the region of interest.
+    2. Compute monthly climatology for area averaged total SST from that region.
+    3. Subtract climatology from area averaged total SST time series to obtain anomalies.
+    4. Normalize anomalies by its standard deviation over the climatological period.
+
+    Parameters
+    ----------
+    data_set: xarray.DataSet
+        Dataset containing an SST field.
+    sst_name: str
+        Name of the Sea-Surface Temperature field. Defaults to "sea-surface-temperature".
+
+    Returns
+    -------
+    xarray.DataArray
+        Time series containing the SSTA_MED index.
+
+    """
+    sst = area_mean_weighted(
+        dobj=data_set[sst_name],
+        lat_south=30,
+        lat_north=45,
+        lon_west=0,
+        lon_east=25,
+    )
+
+    climatology = sst.groupby("time.month").mean("time")
+
+    std_dev = sst.std("time")
+
+    SSTA_MED = (sst.groupby("time.month") - climatology) / std_dev
+    SSTA_MED = SSTA_MED.rename("SSTA_MED")
+
+    return SSTA_MED
+
+
+def hurricane_main_development_region_SST(data_set, sst_name="sea-surface-temperature"):
+    """Calculate the sea-surface temperature (SST) anomaly index in Hurricane main development region (SSTA_HMDR)
+
+    The Hurricane main development region is defined by a box bordered by 10°N to 20°N and 85°W to 20°W.
+    This translates to 10°N to 20°N and 275°E to 340°E.
+
+    Computation is done as follows:
+    1. Compute area averaged total SST in the region of interest.
+    2. Compute monthly climatology for area averaged total SST from that region.
+    3. Subtract climatology from area averaged total SST time series to obtain anomalies.
+    4. Normalize anomalies by its standard deviation over the climatological period.
+
+    Parameters
+    ----------
+    data_set: xarray.DataSet
+        Dataset containing an SST field.
+    sst_name: str
+        Name of the Sea-Surface Temperature field. Defaults to "sea-surface-temperature".
+
+    Returns
+    -------
+    xarray.DataArray
+        Time series containing the SSTA_HMDR index.
+
+    """
+    sst = area_mean_weighted(
+        dobj=data_set[sst_name],
+        lat_south=10,
+        lat_north=20,
+        lon_west=275,
+        lon_east=340,
+    )
+
+    climatology = sst.groupby("time.month").mean("time")
+
+    std_dev = sst.std("time")
+
+    SSTA_HMDR = (sst.groupby("time.month") - climatology) / std_dev
+    SSTA_HMDR = SSTA_HMDR.rename("SSTA_HMDR")
+
+    return SSTA_HMDR
+
+
 def north_atlantic_sea_surface_salinity(data_set, sss_name="sea-surface-salinity"):
-    """Calculate North-Atlantic Sea-Surface Salinity index.
+    """Calculate North Atlantic Sea-Surface Salinity index (NASSS)
 
     Following https://doi.org/10.1126/sciadv.1501588
     the index is derived from Atlantic sea-surface salinity (SSS) anomalies in a box
@@ -484,8 +741,10 @@ def north_atlantic_sea_surface_salinity(data_set, sss_name="sea-surface-salinity
     cut away from the one used here. We skip this here, for now.
 
     Computation is done as follows:
-    1. Calculate the weighted area average of SSS over 50W-15W, 25N-50N.
-    2. Standardize time series.
+    1. Calculate the weighted area average of SSS in the region of interest.
+    2. Compute monthly climatology for area averaged total SSS from that region.
+    3. Subtract climatology from area averaged total SSS time series to obtain anomalies.
+    4. Normalize anomalies by its standard deviation over the climatological period.
 
     Parameters
     ----------
@@ -500,21 +759,157 @@ def north_atlantic_sea_surface_salinity(data_set, sss_name="sea-surface-salinity
         Time series containing the NASSS index.
 
     """
-    sss = data_set[sss_name]
-
-    sss_box_ave = area_mean_weighted(
-        sss,
+    sss = area_mean_weighted(
+        data_set[sss_name],
         lat_south=25,
         lat_north=50,
         lon_west=-50,
         lon_east=-15,
     )
 
-    NASSS = (sss_box_ave - sss_box_ave.mean("time")) / sss_box_ave.std("time")
+    climatology = sss.groupby("time.month").mean("time")
 
+    std_dev = sss.std("time")
+
+    NASSS = (sss.groupby("time.month") - climatology) / std_dev
     NASSS = NASSS.rename("NASSS")
 
     return NASSS
+
+
+def north_atlantic_sea_surface_salinity_west(data_set, sss_name="sea-surface-salinity"):
+    """Calculate the Sea-Surface Salinity index in the Western part of the North Atlantic region (NASSS_W)
+
+    Following https://doi.org/10.1126/sciadv.1501588
+    the index is derived from Atlantic sea-surface salinity (SSS) anomalies. Here we focus on the Western part
+    of the North Atlantic, defined by a box bordered by 25°N to 38°N and 50°W to 40°W.
+    This translates to 25°N to 38°N and 310°E to 320°E.
+
+    Computation is done as follows:
+    1. Calculate the weighted area average of SSS in the region of interest.
+    2. Compute monthly climatology for area averaged total SSS from that region.
+    3. Subtract climatology from area averaged total SSS time series to obtain anomalies.
+    4. Normalize anomalies by its standard deviation over the climatological period.
+
+    Parameters
+    ----------
+    data_set: xarray.DataSet
+        Dataset containing an SSS field.
+    sss_name: str
+        Name of the Sea-Surface Salinity field. Defaults to "sea-surface-salinity".
+
+    Returns
+    -------
+    xarray.DataArray
+        Time series containing the NASSS_W index.
+
+    """
+    sss = area_mean_weighted(
+        data_set[sss_name],
+        lat_south=25,
+        lat_north=38,
+        lon_west=310,
+        lon_east=320,
+    )
+
+    climatology = sss.groupby("time.month").mean("time")
+
+    std_dev = sss.std("time")
+
+    NASSS_W = (sss.groupby("time.month") - climatology) / std_dev
+    NASSS_W = NASSS_W.rename("NASSS_W")
+
+    return NASSS_W
+
+
+def north_atlantic_sea_surface_salinity_east(data_set, sss_name="sea-surface-salinity"):
+    """Calculate the Sea-Surface Salinity index in the Eastern part of the North Atlantic region (NASSS_E)
+
+    Following https://doi.org/10.1126/sciadv.1501588
+    the index is derived from Atlantic sea-surface salinity (SSS) anomalies. Here we focus on the Eastern part
+    of the North Atlantic, defined by a box bordered by 25°N to 50°N and 40°W to 15°W.
+    This translates to 25°N to 50°N and 320°E to 345°E.
+
+    Computation is done as follows:
+    1. Calculate the weighted area average of SSS in the region of interest.
+    2. Compute monthly climatology for area averaged total SSS from that region.
+    3. Subtract climatology from area averaged total SSS time series to obtain anomalies.
+    4. Normalize anomalies by its standard deviation over the climatological period.
+
+    Parameters
+    ----------
+    data_set: xarray.DataSet
+        Dataset containing an SSS field.
+    sss_name: str
+        Name of the Sea-Surface Salinity field. Defaults to "sea-surface-salinity".
+
+    Returns
+    -------
+    xarray.DataArray
+        Time series containing the NASSS_E index.
+
+    """
+    sss = area_mean_weighted(
+        data_set[sss_name],
+        lat_south=25,
+        lat_north=50,
+        lon_west=320,
+        lon_east=345,
+    )
+
+    climatology = sss.groupby("time.month").mean("time")
+
+    std_dev = sss.std("time")
+
+    NASSS_E = (sss.groupby("time.month") - climatology) / std_dev
+    NASSS_E = NASSS_E.rename("NASSS_E")
+
+    return NASSS_E
+
+
+def south_atlantic_sea_surface_salinity(data_set, sss_name="sea-surface-salinity"):
+    """Calculate South Atlantic Sea-Surface Salinity index (SASSS)
+
+    Following https://doi.org/10.1126/sciadv.1501588
+    the index is derived from Atlantic sea-surface salinity (SSS) anomalies. Here we focus on
+    the South Atlantic region, defined by a box bordered by 22.5°S to 10°S and 42°W to 10°W.
+    This translates to -22.5°N to -10°N and 318°E to 350°E.
+
+    Computation is done as follows:
+    1. Calculate the weighted area average of SSS in the region of interest.
+    2. Compute monthly climatology for area averaged total SSS from that region.
+    3. Subtract climatology from area averaged total SSS time series to obtain anomalies.
+    4. Normalize anomalies by its standard deviation over the climatological period.
+
+    Parameters
+    ----------
+    data_set: xarray.DataSet
+        Dataset containing an SSS field.
+    sss_name: str
+        Name of the Sea-Surface Salinity field. Defaults to "sea-surface-salinity".
+
+    Returns
+    -------
+    xarray.DataArray
+        Time series containing the SASSS index.
+
+    """
+    sss = area_mean_weighted(
+        data_set[sss_name],
+        lat_south=-22.5,
+        lat_north=-10,
+        lon_west=318,
+        lon_east=350,
+    )
+
+    climatology = sss.groupby("time.month").mean("time")
+
+    std_dev = sss.std("time")
+
+    SASSS = (sss.groupby("time.month") - climatology) / std_dev
+    SASSS = SASSS.rename("SASSS")
+
+    return SASSS
 
 
 def sea_air_surface_temperature_anomaly_north_all(
@@ -905,7 +1300,22 @@ class ClimateIndexFunctions(Enum):
     el_nino_southern_oscillation_3 = partial(el_nino_southern_oscillation_3)
     el_nino_southern_oscillation_34 = partial(el_nino_southern_oscillation_34)
     el_nino_southern_oscillation_4 = partial(el_nino_southern_oscillation_4)
+    tropical_north_atlantic_SST = partial(tropical_north_atlantic_SST)
+    tropical_south_atlantic_SST = partial(tropical_south_atlantic_SST)
+    eastern_subtropical_indian_ocean_SST = partial(eastern_subtropical_indian_ocean_SST)
+    western_subtropical_indian_ocean_SST = partial(western_subtropical_indian_ocean_SST)
+    mediterranean_SST = partial(mediterranean_SST)
+    hurricane_main_development_region_SST = partial(
+        hurricane_main_development_region_SST
+    )
     north_atlantic_sea_surface_salinity = partial(north_atlantic_sea_surface_salinity)
+    north_atlantic_sea_surface_salinity_west = partial(
+        north_atlantic_sea_surface_salinity_west
+    )
+    north_atlantic_sea_surface_salinity_east = partial(
+        north_atlantic_sea_surface_salinity_east
+    )
+    south_atlantic_sea_surface_salinity = partial(south_atlantic_sea_surface_salinity)
     sea_air_surface_temperature_anomaly_north_all = partial(
         sea_air_surface_temperature_anomaly_north_all
     )

--- a/data/test_data/regrid_CESM_SSS_data.py
+++ b/data/test_data/regrid_CESM_SSS_data.py
@@ -83,7 +83,6 @@ for infile, outfile, gridfile in zip(
     binned.coords["lon"] = target_grid.lon
 
     binned = binned.rename({"TLAT_bin": "lat"})
-    binned = binned.isel(lat=slice(None, None, -1))
     binned.coords["lat"] = target_grid.lat
     binned.attrs.update(original_data_set.SALT.attrs)
 

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -9,13 +9,18 @@ from numpy.testing import assert_allclose, assert_almost_equal
 
 from climate_index_collection.data_loading import VARNAME_MAPPING, load_data_set
 from climate_index_collection.indices import (
+    eastern_subtropical_indian_ocean_SST,
     el_nino_southern_oscillation_3,
     el_nino_southern_oscillation_4,
     el_nino_southern_oscillation_12,
     el_nino_southern_oscillation_34,
+    hurricane_main_development_region_SST,
+    mediterranean_SST,
     north_atlantic_oscillation,
     north_atlantic_oscillation_pc,
     north_atlantic_sea_surface_salinity,
+    north_atlantic_sea_surface_salinity_east,
+    north_atlantic_sea_surface_salinity_west,
     pacific_decadal_oscillation_pc,
     sahel_precipitation_anomaly,
     sea_air_surface_temperature_anomaly_north_all,
@@ -24,9 +29,13 @@ from climate_index_collection.indices import (
     sea_air_surface_temperature_anomaly_south_all,
     sea_air_surface_temperature_anomaly_south_land,
     sea_air_surface_temperature_anomaly_south_ocean,
+    south_atlantic_sea_surface_salinity,
     southern_annular_mode,
     southern_annular_mode_pc,
     southern_oscillation,
+    tropical_north_atlantic_SST,
+    tropical_south_atlantic_SST,
+    western_subtropical_indian_ocean_SST,
 )
 
 
@@ -381,6 +390,168 @@ def test_ENSO4_naming(source_name):
 
 
 @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_TNA_zeromean(source_name):
+    """Ensure that Tropical North Atlantic SST anomaly index has zero mean."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    SSTA_TNA = tropical_north_atlantic_SST(data_set)
+
+    # Check, if calculated index has zero mean:
+    assert_almost_equal(actual=SSTA_TNA.mean("time").values[()], desired=0, decimal=3)
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_TNA_naming(source_name):
+    """Ensure that the index is named correctly."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    result = tropical_north_atlantic_SST(data_set)
+
+    assert result.name == "SSTA_TNA"
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_TSA_zeromean(source_name):
+    """Ensure that Tropical South Atlantic SST anomaly index has zero mean."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    SSTA_TSA = tropical_south_atlantic_SST(data_set)
+
+    # Check, if calculated index has zero mean:
+    assert_almost_equal(actual=SSTA_TSA.mean("time").values[()], desired=0, decimal=3)
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_TSA_naming(source_name):
+    """Ensure that the index is named correctly."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    result = tropical_south_atlantic_SST(data_set)
+
+    assert result.name == "SSTA_TSA"
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_ESIO_zeromean(source_name):
+    """Ensure that Eastern Subtropical Indian Ocean SST anomaly index has zero mean."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    SSTA_ESIO = eastern_subtropical_indian_ocean_SST(data_set)
+
+    # Check, if calculated index has zero mean:
+    assert_almost_equal(actual=SSTA_ESIO.mean("time").values[()], desired=0, decimal=3)
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_ESIO_naming(source_name):
+    """Ensure that the index is named correctly."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    result = eastern_subtropical_indian_ocean_SST(data_set)
+
+    assert result.name == "SSTA_ESIO"
+
+
+# @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+# def test_SSTA_WSIO_zeromean(source_name):
+#     """Ensure that Western Subtropical Indian Ocean SST anomaly index has zero mean."""
+#     # Load test data
+#     TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+#     data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+#     # Calculate index
+#     SSTA_WSIO = western_subtropical_indian_ocean_SST(data_set)
+
+#     # Check, if calculated index has zero mean:
+#     assert_almost_equal(actual=SSTA_WSIO.mean("time").values[()], desired=0, decimal=3)
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_WSIO_naming(source_name):
+    """Ensure that the index is named correctly."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    result = western_subtropical_indian_ocean_SST(data_set)
+
+    assert result.name == "SSTA_WSIO"
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_MED_zeromean(source_name):
+    """Ensure that Mediterranean Sea SST anomaly index has zero mean."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    SSTA_MED = mediterranean_SST(data_set)
+
+    # Check, if calculated index has zero mean:
+    assert_almost_equal(actual=SSTA_MED.mean("time").values[()], desired=0, decimal=3)
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_MED_naming(source_name):
+    """Ensure that the index is named correctly."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    result = mediterranean_SST(data_set)
+
+    assert result.name == "SSTA_MED"
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_HMDR_zeromean(source_name):
+    """Ensure that Mediterranean Sea SST anomaly index has zero mean."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    SSTA_HMDR = hurricane_main_development_region_SST(data_set)
+
+    # Check, if calculated index has zero mean:
+    assert_almost_equal(actual=SSTA_HMDR.mean("time").values[()], desired=0, decimal=3)
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_HMDR_naming(source_name):
+    """Ensure that the index is named correctly."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    result = hurricane_main_development_region_SST(data_set)
+
+    assert result.name == "SSTA_HMDR"
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
 def test_NASSS_metadata(source_name):
     """Ensure that index only contains time dimension."""
     # Load test data
@@ -409,8 +580,8 @@ def test_NASSS_naming(source_name):
 
 
 @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
-def test_NASSS_standardisation(source_name):
-    """Ensure that standardisation works correctly."""
+def test_NASSS_zeromean(source_name):
+    """Ensure that the index has zero mean."""
     # Load test data
     TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
     data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
@@ -418,9 +589,134 @@ def test_NASSS_standardisation(source_name):
     # Calculate NASSS index
     NASSS = north_atlantic_sea_surface_salinity(data_set)
 
-    # Check, if calculated NASSS index has zero mean and unit std dev:
+    # Check, if calculated NASSS index has zero mean:
     assert_almost_equal(actual=NASSS.mean("time").values[()], desired=0, decimal=3)
-    assert_almost_equal(actual=NASSS.std("time").values[()], desired=1, decimal=3)
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_NASSS_W_metadata(source_name):
+    """Ensure that index only contains time dimension."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate NASSS_W index
+    NASSS_W = north_atlantic_sea_surface_salinity_west(data_set)
+
+    # Check, if calculated index only has one dimension: 'time'
+    assert NASSS_W.dims[0] == "time"
+    assert len(NASSS_W.dims) == 1
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_NASSS_W_naming(source_name):
+    """Ensure that the index is named correctly."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate NASSS_W index
+    NASSS_W = north_atlantic_sea_surface_salinity_west(data_set)
+
+    assert NASSS_W.name == "NASSS_W"
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_NASSS_W_zeromean(source_name):
+    """Ensure that the index has zero mean."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate NASSS index
+    NASSS_W = north_atlantic_sea_surface_salinity_west(data_set)
+
+    # Check, if calculated NASSS index has zero mean:
+    assert_almost_equal(actual=NASSS_W.mean("time").values[()], desired=0, decimal=3)
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_NASSS_E_metadata(source_name):
+    """Ensure that index only contains time dimension."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate NASSS_W index
+    NASSS_E = north_atlantic_sea_surface_salinity_east(data_set)
+
+    # Check, if calculated index only has one dimension: 'time'
+    assert NASSS_E.dims[0] == "time"
+    assert len(NASSS_E.dims) == 1
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_NASSS_E_naming(source_name):
+    """Ensure that the index is named correctly."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate NASSS_E index
+    NASSS_E = north_atlantic_sea_surface_salinity_east(data_set)
+
+    assert NASSS_E.name == "NASSS_E"
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_NASSS_E_zeromean(source_name):
+    """Ensure that the index has zero mean."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate NASSS index
+    NASSS_E = north_atlantic_sea_surface_salinity_east(data_set)
+
+    # Check, if calculated NASSS index has zero mean:
+    assert_almost_equal(actual=NASSS_E.mean("time").values[()], desired=0, decimal=3)
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SASSS_metadata(source_name):
+    """Ensure that index only contains time dimension."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate SASSS index
+    SASSS = south_atlantic_sea_surface_salinity(data_set)
+
+    # Check, if calculated NASSS index only has one dimension: 'time'
+    assert SASSS.dims[0] == "time"
+    assert len(SASSS.dims) == 1
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SASSS_naming(source_name):
+    """Ensure that the index is named correctly."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate NASSS index
+    SASSS = south_atlantic_sea_surface_salinity(data_set)
+
+    assert SASSS.name == "SASSS"
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SASSS_zeromean(source_name):
+    """Ensure that the index has zero mean."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate SASSS index
+    SASSS = south_atlantic_sea_surface_salinity(data_set)
+
+    # Check, if calculated NASSS index has zero mean:
+    assert_almost_equal(actual=SASSS.mean("time").values[()], desired=0, decimal=3)
 
 
 @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -21,6 +21,7 @@ from climate_index_collection.indices import (
     north_atlantic_sea_surface_salinity,
     north_atlantic_sea_surface_salinity_east,
     north_atlantic_sea_surface_salinity_west,
+    north_pacific,
     pacific_decadal_oscillation_pc,
     sahel_precipitation_anomaly,
     sea_air_surface_temperature_anomaly_north_all,
@@ -282,6 +283,21 @@ def test_NAO_PC_correlation(source_name):
 
 
 @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_enso12_metadata(source_name):
+    """Ensure that index only contains time dimension."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate ENSO 1+2 index
+    ENSO12 = el_nino_southern_oscillation_12(data_set)
+
+    # Check, if calculated index only has one dimension: 'time'
+    assert ENSO12.dims[0] == "time"
+    assert len(ENSO12.dims) == 1
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
 def test_enso12_zeromean(source_name):
     """Ensure that ENSO 1+2 has zero mean."""
     # Load test data
@@ -306,6 +322,21 @@ def test_ENSO12_naming(source_name):
     result = el_nino_southern_oscillation_12(data_set)
 
     assert result.name == "ENSO12"
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_enso3_metadata(source_name):
+    """Ensure that index only contains time dimension."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate ENSO 3 index
+    ENSO3 = el_nino_southern_oscillation_3(data_set)
+
+    # Check, if calculated index only has one dimension: 'time'
+    assert ENSO3.dims[0] == "time"
+    assert len(ENSO3.dims) == 1
 
 
 @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
@@ -336,6 +367,21 @@ def test_ENSO3_naming(source_name):
 
 
 @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_enso34_metadata(source_name):
+    """Ensure that index only contains time dimension."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate ENSO 3.4 index
+    ENSO34 = el_nino_southern_oscillation_34(data_set)
+
+    # Check, if calculated index only has one dimension: 'time'
+    assert ENSO34.dims[0] == "time"
+    assert len(ENSO34.dims) == 1
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
 def test_enso34_zeromean(source_name):
     """Ensure that ENSO 3.4 has zero mean."""
     # Load test data
@@ -360,6 +406,21 @@ def test_ENSO34_naming(source_name):
     result = el_nino_southern_oscillation_34(data_set)
 
     assert result.name == "ENSO34"
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_enso4_metadata(source_name):
+    """Ensure that index only contains time dimension."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate ENSO 4 index
+    ENSO4 = el_nino_southern_oscillation_4(data_set)
+
+    # Check, if calculated index only has one dimension: 'time'
+    assert ENSO4.dims[0] == "time"
+    assert len(ENSO4.dims) == 1
 
 
 @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
@@ -390,6 +451,21 @@ def test_ENSO4_naming(source_name):
 
 
 @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_TNA_metadata(source_name):
+    """Ensure that index only contains time dimension."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    SSTA_TNA = tropical_north_atlantic_SST(data_set)
+
+    # Check, if calculated index only has one dimension: 'time'
+    assert SSTA_TNA.dims[0] == "time"
+    assert len(SSTA_TNA.dims) == 1
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
 def test_SSTA_TNA_zeromean(source_name):
     """Ensure that Tropical North Atlantic SST anomaly index has zero mean."""
     # Load test data
@@ -414,6 +490,21 @@ def test_SSTA_TNA_naming(source_name):
     result = tropical_north_atlantic_SST(data_set)
 
     assert result.name == "SSTA_TNA"
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_TSA_metadata(source_name):
+    """Ensure that index only contains time dimension."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    SSTA_TSA = tropical_south_atlantic_SST(data_set)
+
+    # Check, if calculated index only has one dimension: 'time'
+    assert SSTA_TSA.dims[0] == "time"
+    assert len(SSTA_TSA.dims) == 1
 
 
 @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
@@ -444,6 +535,21 @@ def test_SSTA_TSA_naming(source_name):
 
 
 @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_ESIO_metadata(source_name):
+    """Ensure that index only contains time dimension."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    SSTA_ESIO = eastern_subtropical_indian_ocean_SST(data_set)
+
+    # Check, if calculated index only has one dimension: 'time'
+    assert SSTA_ESIO.dims[0] == "time"
+    assert len(SSTA_ESIO.dims) == 1
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
 def test_SSTA_ESIO_zeromean(source_name):
     """Ensure that Eastern Subtropical Indian Ocean SST anomaly index has zero mean."""
     # Load test data
@@ -468,6 +574,21 @@ def test_SSTA_ESIO_naming(source_name):
     result = eastern_subtropical_indian_ocean_SST(data_set)
 
     assert result.name == "SSTA_ESIO"
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_WSIO_metadata(source_name):
+    """Ensure that index only contains time dimension."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    SSTA_WSIO = western_subtropical_indian_ocean_SST(data_set)
+
+    # Check, if calculated index only has one dimension: 'time'
+    assert SSTA_WSIO.dims[0] == "time"
+    assert len(SSTA_WSIO.dims) == 1
 
 
 # @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
@@ -498,6 +619,21 @@ def test_SSTA_WSIO_naming(source_name):
 
 
 @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_MED_metadata(source_name):
+    """Ensure that index only contains time dimension."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    SSTA_MED = mediterranean_SST(data_set)
+
+    # Check, if calculated index only has one dimension: 'time'
+    assert SSTA_MED.dims[0] == "time"
+    assert len(SSTA_MED.dims) == 1
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
 def test_SSTA_MED_zeromean(source_name):
     """Ensure that Mediterranean Sea SST anomaly index has zero mean."""
     # Load test data
@@ -522,6 +658,21 @@ def test_SSTA_MED_naming(source_name):
     result = mediterranean_SST(data_set)
 
     assert result.name == "SSTA_MED"
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_HMDR_metadata(source_name):
+    """Ensure that index only contains time dimension."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    SSTA_HMDR = hurricane_main_development_region_SST(data_set)
+
+    # Check, if calculated index only has one dimension: 'time'
+    assert SSTA_HMDR.dims[0] == "time"
+    assert len(SSTA_HMDR.dims) == 1
 
 
 @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
@@ -794,6 +945,21 @@ def test_SASTAI_north_all_naming(source_name, index_function):
 
 
 @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_sahel_precip_metadata(source_name):
+    """Ensure that index only contains time dimension."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate index
+    Sahel_precip = sahel_precipitation_anomaly(data_set)
+
+    # Check, if calculated index only has one dimension: 'time'
+    assert Sahel_precip.dims[0] == "time"
+    assert len(Sahel_precip.dims) == 1
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
 def test_sahel_precip_zeromean(source_name):
     """Ensure that Sahel precipitation anomaly index has zero mean."""
     # Load test data
@@ -863,3 +1029,45 @@ def test_PDO_PC_naming(source_name):
     PDO_PC = pacific_decadal_oscillation_pc(data_set)
 
     assert PDO_PC.name == "PDO_PC"
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_NP_metadata(source_name):
+    """Ensure that index only contains time dimension."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate NP index
+    NP = north_pacific(data_set)
+
+    # Check, if calculated index only has one dimension: 'time'
+    assert NP.dims[0] == "time"
+    assert len(NP.dims) == 1
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_NP_zeromean(source_name):
+    """Ensure that NP index has zero mean."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate NP index
+    NP = north_pacific(data_set)
+
+    # Check, if calculated NP index has zero mean:
+    assert_almost_equal(actual=NP.mean("time").values[()], desired=0, decimal=3)
+
+
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_NP_naming(source_name):
+    """Ensure that the index is named correctly."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+
+    # Calculate NP index
+    result = north_pacific(data_set)
+
+    assert result.name == "NP"

--- a/tests/test_indices.py
+++ b/tests/test_indices.py
@@ -591,18 +591,18 @@ def test_SSTA_WSIO_metadata(source_name):
     assert len(SSTA_WSIO.dims) == 1
 
 
-# @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
-# def test_SSTA_WSIO_zeromean(source_name):
-#     """Ensure that Western Subtropical Indian Ocean SST anomaly index has zero mean."""
-#     # Load test data
-#     TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
-#     data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
+@pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))
+def test_SSTA_WSIO_zeromean(source_name):
+    """Ensure that Western Subtropical Indian Ocean SST anomaly index has zero mean."""
+    # Load test data
+    TEST_DATA_PATH = Path(__file__).parent / "../data/test_data/"
+    data_set = load_data_set(data_path=TEST_DATA_PATH, data_source_name=source_name)
 
-#     # Calculate index
-#     SSTA_WSIO = western_subtropical_indian_ocean_SST(data_set)
+    # Calculate index
+    SSTA_WSIO = western_subtropical_indian_ocean_SST(data_set)
 
-#     # Check, if calculated index has zero mean:
-#     assert_almost_equal(actual=SSTA_WSIO.mean("time").values[()], desired=0, decimal=3)
+    # Check, if calculated index has zero mean:
+    assert_almost_equal(actual=SSTA_WSIO.mean("time").values[()], desired=0, decimal=3)
 
 
 @pytest.mark.parametrize("source_name", list(VARNAME_MAPPING.keys()))


### PR DESCRIPTION
Add several new indices:
- Tropical North Atlantic SST anomaly index
- Tropical South Atlantic SST anomaly index
- Eastern Subtropical Indian Ocean SST anomaly index
- Western Subtropical Indian Ocean SST anomaly index
- Mediterranean SST anomaly index
- Hurricane main development region SST anomaly index

Plus modify existing North Atlantic SSS anomaly index: It was only standardized. But I think, the explicit computation of anomalies was missing. Based on the new modified version, add:
- North Atlantic SSS anomaly index for Western box
- North Atlantic SSS anomaly index for Eastern box
- South Atlantic SSS anomaly index

However, there seems to be a problem with SST data from CESM model: There are large regions (over ocean) with SST=0. I realized that, because "zero mean" test for Western Subtropical Indian Ocean SST anomaly index failed, since mean and std dev are ZERO and dividing by ZERO leads to NaN values in resulting index, which then has no valid mean value. --> This needs to be further investigated (see #118). 

Disabled "zero mean" test for Western Subtropical Indian Ocean SST anomaly index, until solved!